### PR TITLE
Add support for custom gm_opts

### DIFF
--- a/src/gm_options.erl
+++ b/src/gm_options.erl
@@ -9,6 +9,9 @@
 %% Options ordered alphabetically
 %% =====================================================
 
+% For all other unsupported custom opts
+opt({custom, Opt}) -> {Opt};
+
 opt('+adjoin') -> {"+adjoin"};
 opt(adjoin) -> {"-adjoin"};
 opt({background, Color}) ->


### PR DESCRIPTION
Add ability to set custom opts without the need to define it in the gm_options module everytime