### PR TITLE
Add configuration required to publish to hex.

### DIFF
--- a/src/gm.app.src
+++ b/src/gm.app.src
@@ -8,5 +8,9 @@
                 stdlib
             ]},
         {modules, [gm, gm_format_char, gm_options]},
-        {env, []}
+        {env, []},
+        {licenses, ["MIT"]},
+        {pkg_name, "erl_gm"},
+        {maintainers, ["Chase James"]},
+        {links, [{"Github", "https://github.com/nuex/erl_gm"}]}
     ]}.


### PR DESCRIPTION
I've added the necessary configuration to allow Rebar to publish this app to hex.

Closes #9.